### PR TITLE
HELM_CONFIG_HOMEを渡せるようにした

### DIFF
--- a/functions.bash
+++ b/functions.bash
@@ -42,7 +42,7 @@ aws() {
 }
 
 helm() {
-    if [ -z "$HELM_CONFIG_HOME" ] && [ -x "$(which helm)" ]; then
+    if [ -z "$HELM_CONFIG_HOME" ] && [ -x "$(type -P helm)" ]; then
         eval "$(command helm env | grep '^HELM_CONFIG_HOME=')"
     fi
 

--- a/functions.bash
+++ b/functions.bash
@@ -42,11 +42,20 @@ aws() {
 }
 
 helm() {
+    if [ -z "$HELM_CONFIG_HOME" ] && [ -x "$(which helm)" ]; then
+        eval "$(command helm env | grep '^HELM_CONFIG_HOME=')"
+    fi
+
+    # HELM_CONFIG_HOMEをセットしていなくて、helmコマンドがインストールされていない場合は~/.config/helmを強制
+    local helm_config_home="${HELM_CONFIG_HOME:-${HOME}/.config/helm}"
+    install -Dd "$helm_config_home"
+
     docker run --rm \
            -w /workdir \
            -v $(pwd):/workdir \
            -v ${HOME}/.aws:/root/.aws \
            -v $(dirname ${KUBECONFIG:-${HOME}/.kube/config}):/root/.kube \
+           -v "$helm_config_home:/root/.config/helm" \
            --env AWS_PROFILE \
            --env AWS_ACCESS_KEY_ID \
            --env AWS_SECRET_ACCESS_KEY \


### PR DESCRIPTION
`helm env`で`HELM_CONFIG_HOME`を取得できるから、ローカルにHelmが入ってる人はこの値を渡す
ローカルにHelmが入ってない人はとりあえず`~/.config/helm`を渡しちゃう